### PR TITLE
move all C functions to `cfuncs.v`, make the C function declaration clear for *char & using tos3 instead

### DIFF
--- a/gtk/accel_map.v
+++ b/gtk/accel_map.v
@@ -1,7 +1,5 @@
 module gtk
 
-fn C.gtk_accel_map_add_entry(voidptr, int, int)
-
 pub fn accel_map_add_entry(path string, key int, mod_type int) {
 	C.gtk_accel_map_add_entry(C.g_intern_static_string(path.str), key, mod_type)
 }

--- a/gtk/button.v
+++ b/gtk/button.v
@@ -32,5 +32,5 @@ pub fn (b Button) set_label(label string) {
 }
 
 pub fn (b Button) get_label() string {
-	return cstring_to_vstring(C.gtk_button_get_label(b.gtk_widget))
+	return tos3(C.gtk_button_get_label(b.gtk_widget))
 }

--- a/gtk/button.v
+++ b/gtk/button.v
@@ -1,8 +1,5 @@
 module gtk
 
-fn C.gtk_button_set_label(&Widget, voidptr)
-fn C.gtk_button_get_label(&Widget) voidptr
-
 pub struct Button {
 	gtk_widget &Widget
 }

--- a/gtk/cfuncs.v
+++ b/gtk/cfuncs.v
@@ -10,17 +10,17 @@ fn C.gtk_window_set_default_size(&Widget, int, int)
 fn C.gtk_window_set_position(&Widget, int)
 fn C.gtk_window_set_title(&Widget, charptr)
 /* BUTTON */
-fn C.gtk_button_new_with_label(voidptr) &Widget
-fn C.gtk_button_get_label(&Widget) voidptr
-fn C.gtk_button_set_label(&Widget, voidptr)
+fn C.gtk_button_new_with_label(charptr) &Widget
+fn C.gtk_button_get_label(&Widget) charptr
+fn C.gtk_button_set_label(&Widget, charptr)
 /* ENTRY */
 fn C.gtk_entry_new() &Widget
-fn C.gtk_entry_get_text(&Widget) voidptr
+fn C.gtk_entry_get_text(&Widget) charptr
 fn C.gtk_entry_set_invisible_char(&Widget, rune)
-fn C.gtk_entry_set_text(&Widget, string)
+fn C.gtk_entry_set_text(&Widget, charptr)
 fn C.gtk_entry_set_visibility(&Widget, bool)
 /* ACCEL MAP */
-fn C.gtk_accel_map_add_entry(voidptr, int, int)
+fn C.gtk_accel_map_add_entry(charptr, int, int)
 
 fn C.gtk_alignment_new(int, int, int, int) &Widget
 fn C.gtk_hbox_new(bool, int) &Widget
@@ -33,17 +33,17 @@ fn C.gtk_menu_bar_new() &Widget
 fn C.gtk_menu_shell_append(&Widget, &Widget)
 /* MENU ITEM */
 fn C.gtk_menu_item_new() &Widget
-fn C.gtk_menu_item_get_accel_path(&Widget) voidptr
-fn C.gtk_menu_item_get_label(&Widget) voidptr
+fn C.gtk_menu_item_get_accel_path(&Widget) charptr
+fn C.gtk_menu_item_get_label(&Widget) charptr
 fn C.gtk_menu_item_get_use_underline(&Widget) bool
-fn C.gtk_menu_item_new_with_label(voidptr) &Widget
-fn C.gtk_menu_item_set_accel_path(&Widget, voidptr)
-fn C.gtk_menu_item_set_label(&Widget, voidptr)
+fn C.gtk_menu_item_new_with_label(charptr) &Widget
+fn C.gtk_menu_item_set_accel_path(&Widget, charptr)
+fn C.gtk_menu_item_set_label(&Widget, charptr)
 fn C.gtk_menu_item_set_submenu(&Widget, &Widget)
 fn C.gtk_menu_item_set_use_underline(&Widget, bool)
 
-fn C.g_intern_static_string(voidptr) voidptr
-fn C.g_signal_connect(&Widget, voidptr, voidptr, voidptr) int
+fn C.g_intern_static_string(charptr) charptr
+fn C.g_signal_connect(&Widget, charptr, voidptr, voidptr) int
 fn C.gtk_container_add(&Widget, &Widget)
 fn C.gtk_widget_set_size_request(&Widget, int, int)
 fn C.gtk_widget_show_all(&Widget)

--- a/gtk/cfuncs.v
+++ b/gtk/cfuncs.v
@@ -1,28 +1,49 @@
 module gtk
 
-/////////////// MAIN ///////////////
+/* MAIN */
 fn C.gtk_init(int, voidptr)
-fn C.gtk_main()
 fn C.gtk_main_quit()
-/////////////// WINDOW ///////////////
+fn C.gtk_main()
+/* WINDOW */
+fn C.gtk_window_new(int) &Widget
 fn C.gtk_window_set_default_size(&Widget, int, int)
 fn C.gtk_window_set_position(&Widget, int)
 fn C.gtk_window_set_title(&Widget, charptr)
-fn C.gtk_window_new(int) &Widget
-/////////////// BUTTON ///////////////
+/* BUTTON */
 fn C.gtk_button_new_with_label(voidptr) &Widget
+fn C.gtk_button_get_label(&Widget) voidptr
+fn C.gtk_button_set_label(&Widget, voidptr)
+/* ENTRY */
 fn C.gtk_entry_new() &Widget
-fn C.gtk_alignment_new(int, int, int, int) &Widget
-fn C.gtk_vbox_new(bool, int) &Widget
-fn C.gtk_hbox_new(bool, int) &Widget
-fn C.gtk_menu_bar_new() &Widget
-fn C.gtk_menu_new() &Widget
-fn C.gtk_menu_item_new_with_label(voidptr) &Widget
-fn C.gtk_menu_item_new() &Widget
+fn C.gtk_entry_get_text(&Widget) voidptr
+fn C.gtk_entry_set_invisible_char(&Widget, rune)
+fn C.gtk_entry_set_text(&Widget, string)
+fn C.gtk_entry_set_visibility(&Widget, bool)
+/* ACCEL MAP */
+fn C.gtk_accel_map_add_entry(voidptr, int, int)
 
-fn C.g_signal_connect(&Widget, voidptr, voidptr, voidptr) int
-fn C.gtk_container_add(&Widget, &Widget)
-fn C.gtk_widget_show_all(&Widget)
-fn C.gtk_widget_set_size_request(&Widget, int, int)
+fn C.gtk_alignment_new(int, int, int, int) &Widget
+fn C.gtk_hbox_new(bool, int) &Widget
+fn C.gtk_vbox_new(bool, int) &Widget
+/* MENU */
+fn C.gtk_menu_new() &Widget
+/* MENU BAR */
+fn C.gtk_menu_bar_new() &Widget
+/* MENU SHELL */
+fn C.gtk_menu_shell_append(&Widget, &Widget)
+/* MENU ITEM */
+fn C.gtk_menu_item_new() &Widget
+fn C.gtk_menu_item_get_accel_path(&Widget) voidptr
+fn C.gtk_menu_item_get_label(&Widget) voidptr
+fn C.gtk_menu_item_get_use_underline(&Widget) bool
+fn C.gtk_menu_item_new_with_label(voidptr) &Widget
+fn C.gtk_menu_item_set_accel_path(&Widget, voidptr)
+fn C.gtk_menu_item_set_label(&Widget, voidptr)
+fn C.gtk_menu_item_set_submenu(&Widget, &Widget)
+fn C.gtk_menu_item_set_use_underline(&Widget, bool)
 
 fn C.g_intern_static_string(voidptr) voidptr
+fn C.g_signal_connect(&Widget, voidptr, voidptr, voidptr) int
+fn C.gtk_container_add(&Widget, &Widget)
+fn C.gtk_widget_set_size_request(&Widget, int, int)
+fn C.gtk_widget_show_all(&Widget)

--- a/gtk/entry.v
+++ b/gtk/entry.v
@@ -1,10 +1,5 @@
 module gtk
 
-fn C.gtk_entry_get_text(&Widget) voidptr
-fn C.gtk_entry_set_text(&Widget, string)
-fn C.gtk_entry_set_visibility(&Widget, bool)
-fn C.gtk_entry_set_invisible_char(&Widget, rune)
-
 pub struct Entry {
 	gtk_widget &Widget
 }

--- a/gtk/menu.v
+++ b/gtk/menu.v
@@ -1,14 +1,5 @@
 module gtk
 
-fn C.gtk_menu_item_set_submenu(&Widget, &Widget)
-fn C.gtk_menu_shell_append(&C.GtkWidge, &Widget)
-fn C.gtk_menu_item_set_label(&Widget, voidptr)
-fn C.gtk_menu_item_get_label(&Widget) voidptr
-fn C.gtk_menu_item_get_use_underline(&Widget) bool
-fn C.gtk_menu_item_set_use_underline(&Widget, bool)
-fn C.gtk_menu_item_set_accel_path(&Widget, voidptr)
-fn C.gtk_menu_item_get_accel_path(&Widget) voidptr
-
 pub struct MenuBar {
 	gtk_widget &Widget
 }

--- a/gtk/menu.v
+++ b/gtk/menu.v
@@ -65,7 +65,7 @@ pub fn (mi MenuItem) set_label(label string) {
 }
 
 pub fn (mi MenuItem) get_label() string {
-	return cstring_to_vstring(C.gtk_menu_item_get_label(mi.gtk_widget))
+	return tos3(C.gtk_menu_item_get_label(mi.gtk_widget))
 }
 
 pub fn (mi MenuItem) get_use_underline() bool {
@@ -81,7 +81,7 @@ pub fn (mi MenuItem) set_accel_path(label string) {
 }
 
 pub fn (mi MenuItem) get_accel_path() string {
-	return cstring_to_vstring(C.gtk_menu_item_get_accel_path(mi.gtk_widget))
+	return tos3(C.gtk_menu_item_get_accel_path(mi.gtk_widget))
 }
 
 pub fn (mi &MenuItem) get_gtk_widget() &Widget {


### PR DESCRIPTION
with this, increasing the compilation speed up to 20 ms
before:
![hJbkU.png](https://cdn.imgpaste.net/2019/12/17/hJbkU.png)
after:
![hJRZ3.png](https://cdn.imgpaste.net/2019/12/17/hJRZ3.png)